### PR TITLE
fix(ci): remove explicit pnpm version to fix ERR_PNPM_BAD_PM_VERSION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
pnpm/action-setup@v4 'version: 9' conflicts with 'packageManager: pnpm@9.15.0' in package.json. Removing the explicit version lets pnpm/action-setup read from packageManager field instead.